### PR TITLE
Make commute route responsive and link to maps

### DIFF
--- a/high-school.html
+++ b/high-school.html
@@ -45,7 +45,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.yjg-h.ed.jp/" target="_blank">横浜女学院高等学校</a></td>
                                 <td>関内駅</td>
-                                <td>約40分（ブルーライン→関内駅）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/関内駅" target="_blank" class="commute-route">約40分（ブルーライン→関内駅）</a></td>
                                 <td>58</td>
                                 <td>約120名</td>
                                 <td>キリスト教教育を基盤とし、豊かな人間性を育成</td>
@@ -55,7 +55,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.kamakura-jogakuin.ed.jp/" target="_blank">鎌倉女学院高等学校</a></td>
                                 <td>鎌倉駅</td>
-                                <td>約50分（ブルーライン→JR横須賀線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/鎌倉駅" target="_blank" class="commute-route">約50分（ブルーライン→JR横須賀線）</a></td>
                                 <td>60</td>
                                 <td>約160名</td>
                                 <td>自主自律の精神を重んじ、伝統と革新を融合</td>
@@ -65,7 +65,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.shonan-shirahagi.ed.jp/" target="_blank">湘南白百合学園高等学校</a></td>
                                 <td>藤沢駅</td>
-                                <td>約55分（ブルーライン→JR東海道本線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/藤沢駅" target="_blank" class="commute-route">約55分（ブルーライン→JR東海道本線）</a></td>
                                 <td>61</td>
                                 <td>約140名</td>
                                 <td>カトリックの精神に基づく全人教育</td>
@@ -75,7 +75,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.seisen-jogakuin.ed.jp/" target="_blank">清泉女学院高等学校</a></td>
                                 <td>大船駅</td>
-                                <td>約45分（ブルーライン→JR東海道本線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/大船駅" target="_blank" class="commute-route">約45分（ブルーライン→JR東海道本線）</a></td>
                                 <td>61</td>
                                 <td>約120名</td>
                                 <td>カトリック系の教育で、心の教育を重視</td>
@@ -85,7 +85,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.yokohama-kyoritsu.ac.jp/" target="_blank">横浜共立学園高等学校</a></td>
                                 <td>元町・中華街駅</td>
-                                <td>約40分（ブルーライン→みなとみらい線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/元町・中華街駅" target="_blank" class="commute-route">約40分（ブルーライン→みなとみらい線）</a></td>
                                 <td>61</td>
                                 <td>約180名</td>
                                 <td>プロテスタント系の教育で、伝統と革新を融合</td>
@@ -95,7 +95,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.kugenuma-h.pen-kanagawa.ed.jp/" target="_blank">鵠沼高等学校</a></td>
                                 <td>鵠沼駅</td>
-                                <td>約50分（ブルーライン→小田急江ノ島線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/鵠沼駅" target="_blank" class="commute-route">約50分（ブルーライン→小田急江ノ島線）</a></td>
                                 <td>58</td>
                                 <td>約240名</td>
                                 <td>「英語・理数・文理」の3つのコースを設置</td>
@@ -105,7 +105,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.kitakamakura-jogakuin.ed.jp/" target="_blank">北鎌倉女子学園高等学校</a></td>
                                 <td>北鎌倉駅</td>
-                                <td>約55分（ブルーライン→JR横須賀線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/北鎌倉駅" target="_blank" class="commute-route">約55分（ブルーライン→JR横須賀線）</a></td>
                                 <td>60</td>
                                 <td>約200名</td>
                                 <td>少人数制で手厚い進路指導を実施</td>
@@ -115,7 +115,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.ferris.ac.jp/" target="_blank">フェリス女学院高等学校</a></td>
                                 <td>元町・中華街駅</td>
-                                <td>約40分（ブルーライン→みなとみらい線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/元町・中華街駅" target="_blank" class="commute-route">約40分（ブルーライン→みなとみらい線）</a></td>
                                 <td>62</td>
                                 <td>約160名</td>
                                 <td>自由な校風と高い進学実績</td>
@@ -125,7 +125,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.denenchofu.ed.jp/" target="_blank">田園調布学園高等部</a></td>
                                 <td>田園調布駅</td>
-                                <td>約35分（ブルーライン→東急東横線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/田園調布駅" target="_blank" class="commute-route">約35分（ブルーライン→東急東横線）</a></td>
                                 <td>66</td>
                                 <td>約200名</td>
                                 <td>自由な校風で、探究型の学習を推進する女子校</td>
@@ -135,7 +135,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.edu.city.yokohama.lg.jp/school/hs/minami/" target="_blank">横浜市立南高等学校</a></td>
                                 <td>弘明寺駅</td>
-                                <td>約25分（ブルーライン直通）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/弘明寺駅" target="_blank" class="commute-route">約25分（ブルーライン直通）</a></td>
                                 <td>68</td>
                                 <td>約240名</td>
                                 <td>公立中高一貫校で、探究型学習を推進</td>
@@ -145,7 +145,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.edu.city.yokohama.lg.jp/school/hs/kanagawa-sogo/" target="_blank">神奈川総合高等学校</a></td>
                                 <td>横浜駅</td>
-                                <td>約30分（ブルーライン→JR京浜東北線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/横浜駅" target="_blank" class="commute-route">約30分（ブルーライン→JR京浜東北線）</a></td>
                                 <td>68</td>
                                 <td>約280名</td>
                                 <td>多様な選択科目と自由な校風が特徴</td>
@@ -155,7 +155,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.edu.city.yokohama.lg.jp/school/hs/kanazawa/" target="_blank">市立金沢高等学校</a></td>
                                 <td>金沢文庫駅</td>
-                                <td>約40分（ブルーライン→JR京浜東北線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/金沢文庫駅" target="_blank" class="commute-route">約40分（ブルーライン→JR京浜東北線）</a></td>
                                 <td>64</td>
                                 <td>約280名</td>
                                 <td>国際交流が活発で、多様な教育プログラムを提供</td>
@@ -296,5 +296,28 @@
             <p class="disclaimer">※ 情報は2024年時点のものです。最新情報は各学校・塾の公式サイトでご確認ください。</p>
         </div>
     </footer>
+
+    <script>
+        // Enhanced mobile experience
+        document.addEventListener('DOMContentLoaded', function() {
+            // Add touch feedback for commute routes
+            const commuteRoutes = document.querySelectorAll('.commute-route');
+            commuteRoutes.forEach(route => {
+                route.addEventListener('touchstart', function() {
+                    this.style.transform = 'scale(0.95)';
+                });
+                
+                route.addEventListener('touchend', function() {
+                    this.style.transform = 'scale(1)';
+                });
+            });
+            
+            // Improve table scrolling on mobile
+            const tableWrapper = document.querySelector('.table-wrapper');
+            if (tableWrapper && window.innerWidth <= 768) {
+                tableWrapper.style.webkitOverflowScrolling = 'touch';
+            }
+        });
+    </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -89,5 +89,22 @@
             <p class="disclaimer">※ 情報は2024年時点のものです。最新情報は各学校・塾の公式サイトでご確認ください。</p>
         </div>
     </footer>
+
+    <script>
+        // Enhanced mobile experience
+        document.addEventListener('DOMContentLoaded', function() {
+            // Add touch feedback for cards
+            const cards = document.querySelectorAll('.card');
+            cards.forEach(card => {
+                card.addEventListener('touchstart', function() {
+                    this.style.transform = 'translateY(-5px) scale(0.98)';
+                });
+                
+                card.addEventListener('touchend', function() {
+                    this.style.transform = 'translateY(-10px) scale(1)';
+                });
+            });
+        });
+    </script>
 </body>
 </html>

--- a/middle-school.html
+++ b/middle-school.html
@@ -45,7 +45,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.yjg-h.ed.jp/" target="_blank">横浜女学院中学校</a></td>
                                 <td>関内駅</td>
-                                <td>約40分（ブルーライン→関内駅）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/関内駅" target="_blank" class="commute-route">約40分（ブルーライン→関内駅）</a></td>
                                 <td>58</td>
                                 <td>約120名</td>
                                 <td>キリスト教教育を基盤とし、豊かな人間性を育成</td>
@@ -55,7 +55,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.kamakura-jogakuin.ed.jp/" target="_blank">鎌倉女学院中学校</a></td>
                                 <td>鎌倉駅</td>
-                                <td>約50分（ブルーライン→JR横須賀線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/鎌倉駅" target="_blank" class="commute-route">約50分（ブルーライン→JR横須賀線）</a></td>
                                 <td>60</td>
                                 <td>約160名</td>
                                 <td>自主自律の精神を重んじ、伝統と革新を融合</td>
@@ -65,7 +65,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.shonan-shirahagi.ed.jp/" target="_blank">湘南白百合学園中学校</a></td>
                                 <td>藤沢駅</td>
-                                <td>約55分（ブルーライン→JR東海道本線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/藤沢駅" target="_blank" class="commute-route">約55分（ブルーライン→JR東海道本線）</a></td>
                                 <td>61</td>
                                 <td>約140名</td>
                                 <td>カトリックの精神に基づく全人教育</td>
@@ -75,7 +75,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.seisen-jogakuin.ed.jp/" target="_blank">清泉女学院中学校</a></td>
                                 <td>大船駅</td>
-                                <td>約45分（ブルーライン→JR東海道本線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/大船駅" target="_blank" class="commute-route">約45分（ブルーライン→JR東海道本線）</a></td>
                                 <td>61</td>
                                 <td>約120名</td>
                                 <td>カトリック系の教育で、心の教育を重視</td>
@@ -85,7 +85,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.yokohama-kyoritsu.ac.jp/" target="_blank">横浜共立学園中学校</a></td>
                                 <td>元町・中華街駅</td>
-                                <td>約40分（ブルーライン→みなとみらい線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/元町・中華街駅" target="_blank" class="commute-route">約40分（ブルーライン→みなとみらい線）</a></td>
                                 <td>51</td>
                                 <td>約180名</td>
                                 <td>プロテスタント系の教育で、伝統と革新を融合</td>
@@ -95,7 +95,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.misono-jogakuin.ed.jp/" target="_blank">聖園女学院中学校</a></td>
                                 <td>藤沢本町駅</td>
-                                <td>約50分（ブルーライン→JR東海道本線→小田急江ノ島線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/藤沢本町駅" target="_blank" class="commute-route">約50分（ブルーライン→JR東海道本線→小田急江ノ島線）</a></td>
                                 <td>51</td>
                                 <td>約140名</td>
                                 <td>カトリック系の教育で、心の教育を重視</td>
@@ -105,7 +105,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.kanagawa-jogakuin.ed.jp/" target="_blank">神奈川学園中学校</a></td>
                                 <td>横浜駅</td>
-                                <td>約30分（ブルーライン直通）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/横浜駅" target="_blank" class="commute-route">約30分（ブルーライン直通）</a></td>
                                 <td>55</td>
                                 <td>約160名</td>
                                 <td>「人とのつながり」「社会との出会い」を重視した教育</td>
@@ -115,7 +115,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.senzoku.ac.jp/" target="_blank">洗足学園中学校</a></td>
                                 <td>武蔵小杉駅</td>
-                                <td>約40分（ブルーライン→東急東横線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/武蔵小杉駅" target="_blank" class="commute-route">約40分（ブルーライン→東急東横線）</a></td>
                                 <td>57</td>
                                 <td>約200名</td>
                                 <td>音楽教育に力を入れ、多彩なクラブ活動が充実</td>
@@ -125,7 +125,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.denenchofu.ed.jp/" target="_blank">田園調布学園中等部</a></td>
                                 <td>田園調布駅</td>
-                                <td>約35分（ブルーライン→東急東横線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/田園調布駅" target="_blank" class="commute-route">約35分（ブルーライン→東急東横線）</a></td>
                                 <td>66</td>
                                 <td>約200名</td>
                                 <td>自由な校風で、探究型の学習を推進する女子校</td>
@@ -135,7 +135,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.edu.city.yokohama.lg.jp/school/hs/minami/" target="_blank">横浜市立南高等学校附属中学校</a></td>
                                 <td>弘明寺駅</td>
-                                <td>約25分（ブルーライン直通）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/弘明寺駅" target="_blank" class="commute-route">約25分（ブルーライン直通）</a></td>
                                 <td>65</td>
                                 <td>約120名</td>
                                 <td>公立中高一貫校で、探究型学習を重視。高校への内部進学が可能</td>
@@ -145,7 +145,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.yamate-gakuin.ed.jp/" target="_blank">山手学院中学校</a></td>
                                 <td>本郷台駅</td>
-                                <td>約30分（ブルーライン→JR根岸線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/本郷台駅" target="_blank" class="commute-route">約30分（ブルーライン→JR根岸線）</a></td>
                                 <td>60</td>
                                 <td>約240名</td>
                                 <td>文武両道を重視し、多彩な課外活動が魅力</td>
@@ -155,7 +155,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.zushi-kaisei.ac.jp/" target="_blank">逗子開成中学校</a></td>
                                 <td>逗子駅</td>
-                                <td>約40分（ブルーライン→JR横須賀線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/逗子駅" target="_blank" class="commute-route">約40分（ブルーライン→JR横須賀線）</a></td>
                                 <td>62</td>
                                 <td>約180名</td>
                                 <td>海洋教育に力を入れ、独自のカリキュラムを展開</td>
@@ -165,7 +165,7 @@
                             <tr>
                                 <td class="school-name"><a href="https://www.ynu.ac.jp/fs/" target="_blank">横浜国立大学附属横浜中学校</a></td>
                                 <td>三ツ沢上町駅</td>
-                                <td>約30分（ブルーライン→JR根岸線）</td>
+                                <td><a href="https://www.google.com/maps/dir/センター南駅/三ツ沢上町駅" target="_blank" class="commute-route">約30分（ブルーライン→JR根岸線）</a></td>
                                 <td>55</td>
                                 <td>約160名</td>
                                 <td>国立大学附属校で、幅広い教育を提供。高校受験が必要</td>
@@ -300,5 +300,28 @@
             <p class="disclaimer">※ 情報は2024年時点のものです。最新情報は各学校・塾の公式サイトでご確認ください。</p>
         </div>
     </footer>
+
+    <script>
+        // Enhanced mobile experience
+        document.addEventListener('DOMContentLoaded', function() {
+            // Add touch feedback for commute routes
+            const commuteRoutes = document.querySelectorAll('.commute-route');
+            commuteRoutes.forEach(route => {
+                route.addEventListener('touchstart', function() {
+                    this.style.transform = 'scale(0.95)';
+                });
+                
+                route.addEventListener('touchend', function() {
+                    this.style.transform = 'scale(1)';
+                });
+            });
+            
+            // Improve table scrolling on mobile
+            const tableWrapper = document.querySelector('.table-wrapper');
+            if (tableWrapper && window.innerWidth <= 768) {
+                tableWrapper.style.webkitOverflowScrolling = 'touch';
+            }
+        });
+    </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -323,6 +323,42 @@ tr:hover {
     transform: translateY(-2px);
 }
 
+/* Commute Route Styles */
+.commute-route {
+    cursor: pointer;
+    color: #667eea;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    padding: 4px 8px;
+    border-radius: 4px;
+    display: inline-block;
+    position: relative;
+}
+
+.commute-route:hover {
+    background-color: #f0f4ff;
+    color: #764ba2;
+    text-decoration: underline;
+}
+
+.commute-route::after {
+    content: " 🗺️";
+    font-size: 0.8em;
+    margin-left: 4px;
+}
+
+/* Enhanced Table Styles for Mobile */
+@media (max-width: 1024px) {
+    .table-wrapper {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    
+    table {
+        min-width: 800px;
+    }
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
     .main-title {
@@ -340,14 +376,46 @@ tr:hover {
     
     .table-wrapper {
         font-size: 0.8rem;
+        border-radius: 10px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    }
+    
+    table {
+        min-width: 700px;
     }
     
     th, td {
-        padding: 10px 8px;
+        padding: 8px 6px;
+        font-size: 0.75rem;
+    }
+    
+    .school-name {
+        font-size: 0.8rem;
+    }
+    
+    .commute-route {
+        font-size: 0.7rem;
+        padding: 2px 4px;
     }
     
     .features {
         grid-template-columns: 1fr;
+    }
+    
+    .table-header {
+        padding: 15px 20px;
+    }
+    
+    .table-header h2 {
+        font-size: 1.2rem;
+    }
+    
+    .table-header p {
+        font-size: 0.8rem;
+    }
+    
+    .map-wrapper {
+        height: 300px;
     }
 }
 
@@ -366,5 +434,100 @@ tr:hover {
     
     .info-section {
         padding: 25px;
+    }
+    
+    .table-wrapper {
+        font-size: 0.7rem;
+    }
+    
+    table {
+        min-width: 600px;
+    }
+    
+    th, td {
+        padding: 6px 4px;
+        font-size: 0.7rem;
+    }
+    
+    .school-name {
+        font-size: 0.75rem;
+    }
+    
+    .commute-route {
+        font-size: 0.65rem;
+        padding: 1px 3px;
+    }
+    
+    .map-wrapper {
+        height: 250px;
+    }
+    
+    .back-button {
+        padding: 10px 20px;
+        font-size: 0.9rem;
+    }
+}
+
+/* Large Desktop Optimization */
+@media (min-width: 1400px) {
+    .container {
+        max-width: 1400px;
+    }
+    
+    .navigation-cards {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 50px;
+    }
+    
+    .card-content {
+        padding: 40px;
+    }
+    
+    .table-wrapper {
+        font-size: 1rem;
+    }
+    
+    th, td {
+        padding: 18px 15px;
+    }
+    
+    .commute-route {
+        font-size: 0.95rem;
+        padding: 6px 10px;
+    }
+}
+
+/* Touch-friendly improvements for mobile */
+@media (hover: none) and (pointer: coarse) {
+    .commute-route {
+        padding: 8px 12px;
+        font-size: 0.9rem;
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    
+    .card {
+        margin: 0 5px;
+    }
+    
+    .back-button {
+        padding: 15px 25px;
+        font-size: 1rem;
+        min-height: 44px;
+    }
+}
+
+/* Print styles */
+@media print {
+    .commute-route::after {
+        content: "";
+    }
+    
+    .commute-route {
+        color: #000 !important;
+        text-decoration: none !important;
+        background: none !important;
     }
 }


### PR DESCRIPTION
Make commute routes clickable to open Google Maps directions and improve responsive design for all screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f3f16eb-6511-4d63-a836-bf06d31288a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f3f16eb-6511-4d63-a836-bf06d31288a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

