### PR TITLE
Create proficiency level mapping chart

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -935,6 +935,379 @@ tr:hover {
     }
 }
 
+/* Level Chart Styles */
+.level-chart-container {
+    margin: 30px 0;
+}
+
+.chart-controls {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 20px;
+    justify-content: center;
+}
+
+.chart-btn {
+    padding: 10px 20px;
+    border: 2px solid #667eea;
+    background: white;
+    color: #667eea;
+    border-radius: 25px;
+    cursor: pointer;
+    font-weight: 500;
+    transition: all 0.3s ease;
+}
+
+.chart-btn.active {
+    background: #667eea;
+    color: white;
+}
+
+.chart-btn:hover {
+    background: #764ba2;
+    border-color: #764ba2;
+    color: white;
+}
+
+.chart-content {
+    display: none;
+}
+
+.chart-content.active {
+    display: block;
+}
+
+/* Comparison Chart Styles */
+.level-chart {
+    background: white;
+    border-radius: 15px;
+    overflow: hidden;
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.08);
+    margin-bottom: 20px;
+}
+
+.chart-header {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    font-weight: 600;
+}
+
+.level-column {
+    padding: 15px 10px;
+    text-align: center;
+    border-right: 1px solid rgba(255, 255, 255, 0.2);
+    font-size: 0.9rem;
+}
+
+.level-column:last-child {
+    border-right: none;
+}
+
+.chart-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+    border-bottom: 1px solid #e9ecef;
+    transition: background-color 0.3s ease;
+}
+
+.chart-row:hover {
+    background-color: #f8f9fa;
+}
+
+.chart-row:last-child {
+    border-bottom: none;
+}
+
+.level-cell {
+    padding: 12px 10px;
+    text-align: center;
+    border-right: 1px solid #e9ecef;
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.level-cell:last-child {
+    border-right: none;
+}
+
+/* Level Row Colors */
+.chart-row.advanced {
+    background: linear-gradient(90deg, rgba(231, 76, 60, 0.1) 0%, rgba(231, 76, 60, 0.05) 100%);
+}
+
+.chart-row.upper-intermediate {
+    background: linear-gradient(90deg, rgba(230, 126, 34, 0.1) 0%, rgba(230, 126, 34, 0.05) 100%);
+}
+
+.chart-row.intermediate {
+    background: linear-gradient(90deg, rgba(241, 196, 15, 0.1) 0%, rgba(241, 196, 15, 0.05) 100%);
+}
+
+.chart-row.pre-intermediate {
+    background: linear-gradient(90deg, rgba(46, 204, 113, 0.1) 0%, rgba(46, 204, 113, 0.05) 100%);
+}
+
+.chart-row.elementary {
+    background: linear-gradient(90deg, rgba(52, 152, 219, 0.1) 0%, rgba(52, 152, 219, 0.05) 100%);
+}
+
+.chart-row.beginner {
+    background: linear-gradient(90deg, rgba(155, 89, 182, 0.1) 0%, rgba(155, 89, 182, 0.05) 100%);
+}
+
+/* Level Cell Colors */
+.level-cell.cefr {
+    background: #e3f2fd;
+    color: #1976d2;
+    font-weight: 600;
+}
+
+.level-cell.toefl-ibt {
+    background: #f3e5f5;
+    color: #7b1fa2;
+}
+
+.level-cell.toefl-primary {
+    background: #e8f5e8;
+    color: #388e3c;
+}
+
+.level-cell.toefl-junior {
+    background: #fff3e0;
+    color: #f57c00;
+}
+
+.level-cell.eiken {
+    background: #fce4ec;
+    color: #c2185b;
+}
+
+.level-cell.eiken-jr {
+    background: #e0f2f1;
+    color: #00796b;
+}
+
+.level-cell.toeic {
+    background: #f1f8e9;
+    color: #689f38;
+}
+
+/* Detailed Chart Styles */
+.detailed-chart {
+    background: white;
+    border-radius: 15px;
+    padding: 20px;
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.08);
+}
+
+.chart-section {
+    margin-bottom: 30px;
+    padding: 20px;
+    border-radius: 12px;
+    background: #f8f9fa;
+}
+
+.chart-section:last-child {
+    margin-bottom: 0;
+}
+
+.chart-section h4 {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin-bottom: 20px;
+    color: #2c3e50;
+    text-align: center;
+}
+
+.level-details {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 15px;
+}
+
+.level-item {
+    background: white;
+    padding: 15px;
+    border-radius: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    transition: transform 0.3s ease;
+}
+
+.level-item:hover {
+    transform: translateY(-2px);
+}
+
+.level-name {
+    font-weight: 600;
+    color: #2c3e50;
+    font-size: 1rem;
+}
+
+.level-desc {
+    color: #666;
+    font-size: 0.9rem;
+}
+
+/* Chart Legend Styles */
+.chart-legend {
+    background: #f8f9fa;
+    border-radius: 12px;
+    padding: 20px;
+    margin-top: 20px;
+}
+
+.chart-legend h4 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 15px;
+    color: #2c3e50;
+    text-align: center;
+}
+
+.legend-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 15px;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+}
+
+.legend-color {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.legend-color.cefr {
+    background: #1976d2;
+}
+
+.legend-color.toefl-ibt {
+    background: #7b1fa2;
+}
+
+.legend-color.toefl-primary {
+    background: #388e3c;
+}
+
+.legend-color.toefl-junior {
+    background: #f57c00;
+}
+
+.legend-color.eiken {
+    background: #c2185b;
+}
+
+.legend-color.eiken-jr {
+    background: #00796b;
+}
+
+.legend-color.toeic {
+    background: #689f38;
+}
+
+/* Responsive Design for Charts */
+@media (max-width: 1024px) {
+    .chart-header,
+    .chart-row {
+        grid-template-columns: 0.8fr 1fr 1fr 1fr 0.8fr 0.8fr 0.8fr;
+    }
+    
+    .level-column,
+    .level-cell {
+        font-size: 0.8rem;
+        padding: 10px 8px;
+    }
+}
+
+@media (max-width: 768px) {
+    .chart-controls {
+        flex-direction: column;
+        align-items: center;
+    }
+    
+    .chart-btn {
+        width: 200px;
+    }
+    
+    .chart-header,
+    .chart-row {
+        grid-template-columns: 1fr;
+        gap: 0;
+    }
+    
+    .level-column {
+        display: none;
+    }
+    
+    .level-cell {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 12px 15px;
+        border-right: none;
+        border-bottom: 1px solid #e9ecef;
+    }
+    
+    .level-cell::before {
+        content: attr(data-label);
+        font-weight: 600;
+        color: #495057;
+        min-width: 120px;
+    }
+    
+    .level-details {
+        grid-template-columns: 1fr;
+    }
+    
+    .legend-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 480px) {
+    .chart-btn {
+        width: 100%;
+        padding: 12px;
+    }
+    
+    .level-cell {
+        padding: 10px 12px;
+        font-size: 0.75rem;
+    }
+    
+    .level-cell::before {
+        font-size: 0.7rem;
+        min-width: 100px;
+    }
+    
+    .level-item {
+        padding: 12px;
+    }
+    
+    .level-name {
+        font-size: 0.9rem;
+    }
+    
+    .level-desc {
+        font-size: 0.8rem;
+    }
+}
+
 /* Print styles */
 @media print {
     .commute-route::after {
@@ -945,5 +1318,13 @@ tr:hover {
         color: #000 !important;
         text-decoration: none !important;
         background: none !important;
+    }
+    
+    .chart-controls {
+        display: none;
+    }
+    
+    .chart-content {
+        display: block !important;
     }
 }

--- a/toefl.html
+++ b/toefl.html
@@ -125,6 +125,217 @@
                 </div>
             </div>
 
+            <!-- 英語能力指標レベル対応表 -->
+            <div class="info-section">
+                <h3>📊 英語能力指標レベル対応表</h3>
+                <p>TOEFL、CEFR、英検、TOEIC、英検Jrの各指標のレベル対応を視覚的に確認できます。</p>
+                
+                <div class="level-chart-container">
+                    <div class="chart-controls">
+                        <button class="chart-btn active" data-chart="comparison">比較表</button>
+                        <button class="chart-btn" data-chart="detailed">詳細表</button>
+                    </div>
+                    
+                    <!-- 比較表チャート -->
+                    <div id="comparison-chart" class="chart-content active">
+                        <div class="level-chart">
+                            <div class="chart-header">
+                                <div class="level-column">CEFR</div>
+                                <div class="level-column">TOEFL iBT</div>
+                                <div class="level-column">TOEFL Primary</div>
+                                <div class="level-column">TOEFL Junior</div>
+                                <div class="level-column">英検</div>
+                                <div class="level-column">英検Jr</div>
+                                <div class="level-column">TOEIC</div>
+                            </div>
+                            
+                            <div class="chart-row advanced">
+                                <div class="level-cell cefr">C2</div>
+                                <div class="level-cell toefl-ibt">110-120</div>
+                                <div class="level-cell toefl-primary">-</div>
+                                <div class="level-cell toefl-junior">-</div>
+                                <div class="level-cell eiken">1級</div>
+                                <div class="level-cell eiken-jr">-</div>
+                                <div class="level-cell toeic">990</div>
+                            </div>
+                            
+                            <div class="chart-row advanced">
+                                <div class="level-cell cefr">C1</div>
+                                <div class="level-cell toefl-ibt">95-109</div>
+                                <div class="level-cell toefl-primary">-</div>
+                                <div class="level-cell toefl-junior">-</div>
+                                <div class="level-cell eiken">準1級</div>
+                                <div class="level-cell eiken-jr">-</div>
+                                <div class="level-cell toeic">945</div>
+                            </div>
+                            
+                            <div class="chart-row upper-intermediate">
+                                <div class="level-cell cefr">B2</div>
+                                <div class="level-cell toefl-ibt">72-94</div>
+                                <div class="level-cell toefl-primary">-</div>
+                                <div class="level-cell toefl-junior">-</div>
+                                <div class="level-cell eiken">2級</div>
+                                <div class="level-cell eiken-jr">-</div>
+                                <div class="level-cell toeic">785</div>
+                            </div>
+                            
+                            <div class="chart-row intermediate">
+                                <div class="level-cell cefr">B1</div>
+                                <div class="level-cell toefl-ibt">42-71</div>
+                                <div class="level-cell toefl-primary">-</div>
+                                <div class="level-cell toefl-junior">280-300</div>
+                                <div class="level-cell eiken">準2級</div>
+                                <div class="level-cell eiken-jr">-</div>
+                                <div class="level-cell toeic">550</div>
+                            </div>
+                            
+                            <div class="chart-row pre-intermediate">
+                                <div class="level-cell cefr">A2</div>
+                                <div class="level-cell toefl-ibt">-</div>
+                                <div class="level-cell toefl-primary">-</div>
+                                <div class="level-cell toefl-junior">250-279</div>
+                                <div class="level-cell eiken">3級</div>
+                                <div class="level-cell eiken-jr">Gold</div>
+                                <div class="level-cell toeic">225</div>
+                            </div>
+                            
+                            <div class="chart-row elementary">
+                                <div class="level-cell cefr">A1</div>
+                                <div class="level-cell toefl-ibt">-</div>
+                                <div class="level-cell toefl-primary">Step 2: 104-115</div>
+                                <div class="level-cell toefl-junior">200-249</div>
+                                <div class="level-cell eiken">4級</div>
+                                <div class="level-cell eiken-jr">Silver</div>
+                                <div class="level-cell toeic">120</div>
+                            </div>
+                            
+                            <div class="chart-row beginner">
+                                <div class="level-cell cefr">A0</div>
+                                <div class="level-cell toefl-ibt">-</div>
+                                <div class="level-cell toefl-primary">Step 1: 100-109</div>
+                                <div class="level-cell toefl-junior">-</div>
+                                <div class="level-cell eiken">5級</div>
+                                <div class="level-cell eiken-jr">Bronze</div>
+                                <div class="level-cell toeic">-</div>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- 詳細表チャート -->
+                    <div id="detailed-chart" class="chart-content">
+                        <div class="detailed-chart">
+                            <div class="chart-section">
+                                <h4>🟢 初級レベル（A0-A1）</h4>
+                                <div class="level-details">
+                                    <div class="level-item">
+                                        <span class="level-name">英検Jr Bronze</span>
+                                        <span class="level-desc">基本的な単語とフレーズ</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">英検Jr Silver</span>
+                                        <span class="level-desc">簡単な会話と文章理解</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">TOEFL Primary Step 1</span>
+                                        <span class="level-desc">基礎的な英語力（8歳以上）</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">英検5級</span>
+                                        <span class="level-desc">中学初級レベル</span>
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            <div class="chart-section">
+                                <h4>🟡 中級レベル（A2-B1）</h4>
+                                <div class="level-details">
+                                    <div class="level-item">
+                                        <span class="level-name">英検Jr Gold</span>
+                                        <span class="level-desc">日常会話レベル</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">TOEFL Primary Step 2</span>
+                                        <span class="level-desc">発展的な英語力（8歳以上）</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">TOEFL Junior 200-249</span>
+                                        <span class="level-desc">中学生向け基礎レベル</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">英検4級</span>
+                                        <span class="level-desc">中学中級レベル</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">英検3級</span>
+                                        <span class="level-desc">中学卒業レベル</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">TOEFL Junior 250-300</span>
+                                        <span class="level-desc">中学生向け上級レベル</span>
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            <div class="chart-section">
+                                <h4>🔴 上級レベル（B2-C2）</h4>
+                                <div class="level-details">
+                                    <div class="level-item">
+                                        <span class="level-name">英検準2級</span>
+                                        <span class="level-desc">高校中級レベル</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">英検2級</span>
+                                        <span class="level-desc">高校卒業レベル</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">英検準1級</span>
+                                        <span class="level-desc">大学中級レベル</span>
+                                    </div>
+                                    <div class="level-item">
+                                        <span class="level-name">英検1級</span>
+                                        <span class="level-desc">大学上級レベル</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="chart-legend">
+                    <h4>📝 指標の説明</h4>
+                    <div class="legend-grid">
+                        <div class="legend-item">
+                            <span class="legend-color cefr"></span>
+                            <span><strong>CEFR:</strong> ヨーロッパ言語共通参照枠</span>
+                        </div>
+                        <div class="legend-item">
+                            <span class="legend-color toefl-ibt"></span>
+                            <span><strong>TOEFL iBT:</strong> 大学レベルの英語力測定</span>
+                        </div>
+                        <div class="legend-item">
+                            <span class="legend-color toefl-primary"></span>
+                            <span><strong>TOEFL Primary:</strong> 小学生向け英語テスト</span>
+                        </div>
+                        <div class="legend-item">
+                            <span class="legend-color toefl-junior"></span>
+                            <span><strong>TOEFL Junior:</strong> 中学生向け英語テスト</span>
+                        </div>
+                        <div class="legend-item">
+                            <span class="legend-color eiken"></span>
+                            <span><strong>英検:</strong> 実用英語技能検定</span>
+                        </div>
+                        <div class="legend-item">
+                            <span class="legend-color eiken-jr"></span>
+                            <span><strong>英検Jr:</strong> 児童向け英語検定</span>
+                        </div>
+                        <div class="legend-item">
+                            <span class="legend-color toeic"></span>
+                            <span><strong>TOEIC:</strong> ビジネス英語力測定</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- 学習のポイント -->
             <div class="info-section">
                 <h3>学習のポイント</h3>
@@ -348,6 +559,58 @@
                 
                 card.addEventListener('touchend', function() {
                     this.style.transform = 'translateY(-10px) scale(1)';
+                });
+            });
+
+            // Chart switching functionality
+            const chartButtons = document.querySelectorAll('.chart-btn');
+            const chartContents = document.querySelectorAll('.chart-content');
+
+            chartButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const targetChart = this.getAttribute('data-chart');
+                    
+                    // Remove active class from all buttons and contents
+                    chartButtons.forEach(btn => btn.classList.remove('active'));
+                    chartContents.forEach(content => content.classList.remove('active'));
+                    
+                    // Add active class to clicked button and corresponding content
+                    this.classList.add('active');
+                    document.getElementById(targetChart + '-chart').classList.add('active');
+                });
+            });
+
+            // Add data labels for mobile responsive design
+            const levelCells = document.querySelectorAll('.level-cell');
+            const columnHeaders = ['CEFR', 'TOEFL iBT', 'TOEFL Primary', 'TOEFL Junior', '英検', '英検Jr', 'TOEIC'];
+            
+            levelCells.forEach((cell, index) => {
+                const rowIndex = Math.floor(index / 7);
+                const colIndex = index % 7;
+                if (colIndex < columnHeaders.length) {
+                    cell.setAttribute('data-label', columnHeaders[colIndex]);
+                }
+            });
+
+            // Add hover effects for level items
+            const levelItems = document.querySelectorAll('.level-item');
+            levelItems.forEach(item => {
+                item.addEventListener('mouseenter', function() {
+                    this.style.transform = 'translateY(-3px) scale(1.02)';
+                });
+                
+                item.addEventListener('mouseleave', function() {
+                    this.style.transform = 'translateY(0) scale(1)';
+                });
+            });
+
+            // Add click animation for chart buttons
+            chartButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    this.style.transform = 'scale(0.95)';
+                    setTimeout(() => {
+                        this.style.transform = 'scale(1)';
+                    }, 150);
                 });
             });
         });


### PR DESCRIPTION
TOEFLページに英語能力指標レベル対応表のチャートを追加し、TOEFL、CEFR、英検、TOEIC、英検Jrのレベルを比較できるようにしました。

---
<a href="https://cursor.com/background-agent?bcId=bc-abcfc3e2-cac6-4eec-b718-7b7b7c03950f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-abcfc3e2-cac6-4eec-b718-7b7b7c03950f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

